### PR TITLE
Fix: Handle 2-digit video device index correctly

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -31,10 +31,13 @@ int main(int argc, char **argv)
 
     cv::namedWindow("Camera FPS");
     cv::VideoCapture capture;
-    if (strlen(vedio_name) == 1)
-        capture.open((int)(vedio_name[0] - '0'));
-    else
-        capture.open(vedio_name);
+    if (strlen(vedio_name) == 1 || strlen(vedio_name) == 2) {
+                int deviceIndex = atoi(vedio_name);
+                    capture.open(deviceIndex);
+    } else {
+                capture.open(vedio_name);
+    }
+
 
     struct timeval time;
     gettimeofday(&time, nullptr);


### PR DESCRIPTION
When the input for video device is a 2-digit number, the program failed to open the correct video capture device. This commit fixes the issue by properly handling 1-digit and 2-digit device indices using atoi() to convert them to integers, and ensures the video file path is used correctly when the input is not a number.

Tested with both video device indices and file paths to ensure proper functionality.

Testing the ArmSoM-Sige7 device